### PR TITLE
[Feature] Domain 영역에 Viewtype과 그에 맞는 Entity를 매핑하는 Enum Class를 만듭니다.

### DIFF
--- a/data/src/main/java/com/swm/data/network/dto/ScreenDTO.kt
+++ b/data/src/main/java/com/swm/data/network/dto/ScreenDTO.kt
@@ -6,6 +6,7 @@ import com.swm.domain.model.ImageStyle
 import com.swm.domain.model.Screen
 import com.swm.domain.model.Section
 import com.swm.domain.model.TextStyle
+import com.swm.domain.model.ViewType
 
 data class ScreenDTO(
     val screenName: String,
@@ -39,7 +40,7 @@ sealed class SectionDTO {
         val description: String,
     ) : SectionDTO() {
         override fun toEntity() = Section.TitleSection(
-            type = type,
+            type = ViewType.findClassByItsName(type),
             title = title,
             badges = badges.map { it.toEntity() },
             description = description,
@@ -54,10 +55,20 @@ sealed class SectionDTO {
         val description: String,
     ) : SectionDTO() {
         override fun toEntity() = Section.PlusTitleSection(
-            type = type,
+            type = ViewType.findClassByItsName(type),
             firstRowImage = firstRowImage.toEntity(),
             titleText = titleText.toEntity(),
             badges = badges.map { it.toEntity() },
+            description = description,
+        )
+    }
+
+    data class UnKnownSectionDTO(
+        val type: String,
+        val description: String,
+    ) : SectionDTO() {
+        override fun toEntity() = Section.UnKnownSection(
+            type = ViewType.findClassByItsName(type),
             description = description,
         )
     }

--- a/data/src/main/java/com/swm/data/network/dto/ViewTypeDto.kt
+++ b/data/src/main/java/com/swm/data/network/dto/ViewTypeDto.kt
@@ -1,16 +1,16 @@
-package com.swm.domain.model
+package com.swm.data.network.dto
 
 import java.lang.reflect.Type
 
-enum class ViewType(
-    private val viewTypeClass: Type,
+enum class ViewTypeDTO(
+    val viewTypeClass: Type,
 ) {
-    TitleSection(Section.TitleSection::class.java),
-    PlusTitleSection(Section.PlusTitleSection::class.java),
-    UnKnown(Section.UnKnownSection::class.java);
+    TitleSection(SectionDTO.TitleSectionDTO::class.java),
+    PlusTitleSection(SectionDTO.PlusTitleSectionDTO::class.java),
+    UnKnown(SectionDTO.UnKnownSectionDTO::class.java);
 
     companion object {
-        fun findClassByItsName(viewTypeString: String?): ViewType {
+        fun findClassByItsName(viewTypeString: String?): ViewTypeDTO {
             entries.find { it.name == viewTypeString }?.let {
                 return it
             } ?: return UnKnown

--- a/domain/src/main/java/com/swm/domain/model/Screen.kt
+++ b/domain/src/main/java/com/swm/domain/model/Screen.kt
@@ -26,6 +26,12 @@ sealed class Section {
         val badges: List<Badge>,
         val description: String,
     ) : Section()
+
+    data class UnKnownSection(
+        val type: String,
+        val description: String,
+    ) : Section()
+
 }
 
 data class Badge(

--- a/domain/src/main/java/com/swm/domain/model/Screen.kt
+++ b/domain/src/main/java/com/swm/domain/model/Screen.kt
@@ -13,14 +13,14 @@ data class Content(
 
 sealed class Section {
     data class TitleSection(
-        val type: String,
+        val type: ViewType,
         val title: String,
         val badges: List<Badge>,
         val description: String,
     ) : Section()
 
     data class PlusTitleSection(
-        val type: String,
+        val type: ViewType,
         val firstRowImage: ImageStyle,
         val titleText: TextStyle,
         val badges: List<Badge>,
@@ -28,7 +28,7 @@ sealed class Section {
     ) : Section()
 
     data class UnKnownSection(
-        val type: String,
+        val type: ViewType,
         val description: String,
     ) : Section()
 

--- a/domain/src/main/java/com/swm/domain/model/ViewType.kt
+++ b/domain/src/main/java/com/swm/domain/model/ViewType.kt
@@ -1,0 +1,23 @@
+package com.swm.domain.model
+
+import java.lang.reflect.Type
+
+enum class ViewType(
+    private val viewTypeClass: Type,
+) {
+    TitleSection(TitleSection::class.java),
+    PlusTitleSection(PlusTitleSection::class.java),
+    UnKnown(Section.UnKnownSection::class.java);
+
+    companion object {
+        fun findClassByItsName(viewTypeString: String?): ViewType {
+            entries.find { it.name == viewTypeString }?.let {
+                return it
+            } ?: return UnKnown
+        }
+
+        fun findViewTypeClassByItsName(viewTypeString: String?): Type {
+            return findClassByItsName(viewTypeString).viewTypeClass
+        }
+    }
+}


### PR DESCRIPTION
- closed #5 

와.... **Enum class**에 **Type**을 넣을 수 있는 지 몰랐네요...

리플렉션 신기하다............................

<br><br><br>

## 변경사항이 있어요...! 🫡

https://github.com/tgyuuAn/SWM-ServerDriven-AOS/pull/2 에서 응답 값의 **viewType 프로퍼티**가

**String형**에서  `domain -> model -> viewType enum class` 로 내려갈 거에요...!


<br><br><br>

## 새로 알게된 부분 📌

아래와 같이 enum class에 Type을 넣어줄 수 있다.

이 때 Type은 자바의 리플렉션 정보이고, 이를 토대로 클래스를 매핑시켜줄 수 있다.

```kotlin
enum class ViewType(
    private val viewTypeClass: Type,
) {
    TitleSection(Section.TitleSection::class.java),
    PlusTitleSection(Section.PlusTitleSection::class.java),
    UnKnown(Section.UnKnownSection::class.java);

    companion object {
        fun findClassByItsName(viewTypeString: String?): ViewType {
            entries.find { it.name == viewTypeString }?.let {
                return it
            } ?: return UnKnown
        }

        fun findViewTypeClassByItsName(viewTypeString: String?): Type {
            return findClassByItsName(viewTypeString).viewTypeClass
        }
    }
}
```

출처 : [레퍼런스](https://jcodingcraft.tistory.com/13) 